### PR TITLE
Updated Apple store Filter

### DIFF
--- a/resources/script.js
+++ b/resources/script.js
@@ -219,19 +219,16 @@ function authification(url, href, origin, hostname,protocol,pathname,search)
 				 return output; 
         }    
   else if(hostname=="apps.apple.com")
-        {
-            lang=pathname.split('/')[1];
-            default_lang=lang.replace(lang,"us");
-            if(pathname.split('/')[3].startsWith('id')){ 
-              link=hostname+'/'+ default_lang+ '/' +pathname.split('/')[2]+'/'+pathname.split('/')[3];
-              
+            { function extractId(appleStoreLink) {
+              const regex = /\/id(\d+)/;
+              const match = appleStoreLink.match(regex);
+              return match ? match[1] : null;
             }
-           else if(pathname.split('/')[4].startsWith('id')){
-            link=hostname+'/'+ default_lang+ '/' +pathname.split('/')[2]+'/'+pathname.split('/')[4];
-            
-           }
-           var output = compare(link);
-           return output; 
+        const Id = 'id'+ extractId(pathname);
+          if(pathname.includes('developer')){link=hostname+'/developer/'+Id;}
+          else if(pathname.includes('app')){link=hostname+'/app/'+Id;}
+          var output= compare(link);
+          return output;
 
 
         }      


### PR DESCRIPTION
- The previous version does not check for country code, and shows wrong result, when verifying a product with/without countrycode.
- This version can also verify developer id along with product id.

Prod URL format: apps.apple.com/apps/id
Dev URL format: apps.apple.com/developer/id

fixes #46 