### PR TITLE
Add support to /user/ in URL and show warning when individual shorts/videos are submitted by end user

### DIFF
--- a/resources/filters.js
+++ b/resources/filters.js
@@ -46,7 +46,7 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search)
 	else if(origin=="https://www.youtube.com")
       {
         var channel=(pathname.split('/')[1]);
-        if(channel=="channel") { link = hostname +'/' +pathname.split('/')[1]+ '/' + pathname.split('/')[2];}
+        if(channel=="channel" ||channel=="user" ) { link = hostname +'/' +pathname.split('/')[1]+ '/' + pathname.split('/')[2];}
         else if(channel=="c") { 
         var id=pathname.split('/')[2].toLowerCase();
         link= hostname+'/'+id}

--- a/resources/filters.js
+++ b/resources/filters.js
@@ -47,6 +47,7 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search)
       {
         var channel=(pathname.split('/')[1]);
         if(channel=="channel" ||channel=="user" ) { link = hostname +'/' +pathname.split('/')[1]+ '/' + pathname.split('/')[2];}
+        else if(channel=="shorts"|| channel=="watch"){return `<p>Cannot identify individual videos. Please submit the profile URL to verify.</p>`;}
         else if(channel=="c") { 
         var id=pathname.split('/')[2].toLowerCase();
         link= hostname+'/'+id}


### PR DESCRIPTION
Fixes #81 

- Add support to URLS submitted by end user where the url format is of the following `youtube.com/user/.......`
- Shows a warning that it cannot verify a individual video url or a shorts video url.