### PR TITLE
Add filter for crew.work

### DIFF
--- a/resources/filters.js
+++ b/resources/filters.js
@@ -210,7 +210,13 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search,d
     link = hostname;
     var output = compare(link,link);
     return output;
-  }				
+  }	
+  else if(domain=="crew.work"){
+    link=hostname;
+    var output = compare(link,link);
+    return output;
+  }
+  
 	else{
     link=domain;
     


### PR DESCRIPTION
Fixes #103

When `crew.work` domain is detected it adds the subdomain to link. So the URL structure becomes `subdomain.crew.work` which is further used to compare in the database.

For the company `crew.work`, add the subdomain `www` in the database. `www.crew.work`