### PR TITLE
Add keka.com filter

### DIFF
--- a/resources/filters.js
+++ b/resources/filters.js
@@ -216,6 +216,11 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search,d
     var output = compare(link,link);
     return output;
   }
+  else if(domain == "keka.com"){
+    link=hostname;
+    var output= compare(link,link);
+    return output;
+  }
   
 	else{
     link=domain;


### PR DESCRIPTION
fixes #99

Whenever `keka.com` domain is detected, it adds the subdomain to the link used for comparing. So the link sent for comparing will end up like `subdomain.keka.com`, where the subdomain depends on the company.

For the company `keka.com`, the subdomain www should be added to the database.