### PR TITLE
Add darwinbox.in filters

### DIFF
--- a/resources/filters.js
+++ b/resources/filters.js
@@ -225,8 +225,9 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search,d
     link=hostname;
     var output = compare(link,link);
     return output;
-
   }
+
+  
 	else{
     link=domain;
     

--- a/resources/filters.js
+++ b/resources/filters.js
@@ -221,7 +221,12 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search,d
     var output= compare(link,link);
     return output;
   }
-  
+  else if(domain=="darwinbox.in"){
+    link=hostname;
+    var output = compare(link,link);
+    return output;
+
+  }
 	else{
     link=domain;
     


### PR DESCRIPTION
Fixes #97

When `darwinbox.in` domain is detected, it'll add the subdomain to the link for comparing.